### PR TITLE
prefect: add `credentials-dev` and `credentials-prod` volumes

### DIFF
--- a/k8s/prefect/chart/values.yaml
+++ b/k8s/prefect/chart/values.yaml
@@ -182,7 +182,7 @@ agent:
   enabled: true
   prefectLabels:
   - basedosdados-dev
-  jobTemplateFilePath: https://storage.googleapis.com/basedosdados-dev/prefect_job_template/job_template.yaml
+  jobTemplateFilePath: https://storage.googleapis.com/basedosdados-dev/prefect_job_template/template.yaml
   image:
     name: prefecthq/prefect
     tag:

--- a/k8s/prefect/chart/values.yaml
+++ b/k8s/prefect/chart/values.yaml
@@ -1,4 +1,5 @@
-# helm upgrade --install prefect -n prefect prefecthq/prefect-server -f values.yaml
+# helm repo add prefecthq https://prefecthq.github.io/server
+# helm upgrade --install prefect -n prefect prefecthq/prefect-server -f values.yaml --version 2022.09.07
 serverVersionTag: core-0.15.9
 
 prefectVersionTag: 0.15.9

--- a/k8s/prefect/job_template/job_template.yaml
+++ b/k8s/prefect/job_template/job_template.yaml
@@ -17,7 +17,19 @@ spec:
         - name: gcp-sa
           mountPath: /mnt/
           readOnly: true
+        - name: credentials-dev
+          mountPath: /credentials-dev/
+          readOnly: true
+        - name: credentials-prod
+          mountPath: /credentials-prod/
+          readOnly: true
       volumes:
       - name: gcp-sa
         secret:
           secretName: gcp-sa
+      - name: credentials-dev
+        secret:
+          secretName: credentials-dev
+      - name: credentials-prod
+        secret:
+          secretName: credentials-prod

--- a/k8s/prefect_agents/basedosdados-perguntas/chart/values.yaml
+++ b/k8s/prefect_agents/basedosdados-perguntas/chart/values.yaml
@@ -12,7 +12,7 @@ agent:
     name: prefecthq/prefect
     tag: 0.15.9
   serviceAccountName: prefect-agent
-  jobTemplateFilePath: https://storage.googleapis.com/basedosdados-dev/prefect_job_template/job_template.yaml
+  jobTemplateFilePath: https://storage.googleapis.com/basedosdados-dev/prefect_job_template/template.yaml
   apollo_url: http://prefect-apollo.prefect.svc.cluster.local:4200/
   prefect_backend_server: true
   auth_secret_name: ''

--- a/k8s/prefect_agents/basedosdados-projetos/chart/values.yaml
+++ b/k8s/prefect_agents/basedosdados-projetos/chart/values.yaml
@@ -1,4 +1,4 @@
-# helm install prefect-agent prefeitura-rio/prefect-agent -n prefect-agent-basedosdados-projetos -f values.yaml
+# helm upgrade --install prefect-agent prefeitura-rio/prefect-agent -n prefect-agent-basedosdados-projetos -f values.yaml
 
 agent:
   name: prefect-agent

--- a/k8s/prefect_agents/basedosdados-projetos/chart/values.yaml
+++ b/k8s/prefect_agents/basedosdados-projetos/chart/values.yaml
@@ -12,7 +12,7 @@ agent:
     name: prefecthq/prefect
     tag: 0.15.9
   serviceAccountName: prefect-agent
-  jobTemplateFilePath: https://storage.googleapis.com/basedosdados-dev/prefect_job_template/job_template.yaml
+  jobTemplateFilePath: https://storage.googleapis.com/basedosdados-dev/prefect_job_template/template.yaml
   apollo_url: http://prefect-apollo.prefect.svc.cluster.local:4200/
   prefect_backend_server: true
   auth_secret_name: ''

--- a/k8s/prefect_agents/basedosdados/chart/values.yaml
+++ b/k8s/prefect_agents/basedosdados/chart/values.yaml
@@ -14,7 +14,7 @@ agent:
       requests:
         cpu: ''
         memory: ''
-  jobTemplateFilePath: https://storage.googleapis.com/basedosdados-dev/prefect_job_template/job_template.yaml
+  jobTemplateFilePath: https://storage.googleapis.com/basedosdados-dev/prefect_job_template/template.yaml
   name: prefect-agent
   prefectLabels:
   - basedosdados

--- a/k8s/prefect_agents/basedosdados/chart/values.yaml
+++ b/k8s/prefect_agents/basedosdados/chart/values.yaml
@@ -1,4 +1,4 @@
-# helm install prefect-agent prefeitura-rio/prefect-agent -n prefect-agent-basedosdados -f values.yaml
+# helm upgrade --install prefect-agent prefeitura-rio/prefect-agent -n prefect-agent-basedosdados -f values.yaml
 
 agent:
   apollo_url: http://prefect-apollo.prefect.svc.cluster.local:4200/


### PR DESCRIPTION
Esse PR monta os secrets no container adicionando dois volumes, `credentials-dev` e `credentials-prod`

Parte da migração para o monorepo

cc @gabriel-milan @folhesgabriel @laura-l-amaral 