### PR TITLE
feat: scale down prefect 0 resources and agents in helm values

### DIFF
--- a/k8s/prefect/chart/values.yaml
+++ b/k8s/prefect/chart/values.yaml
@@ -56,8 +56,8 @@ hasura:
   env: []
   resources:
     requests:
-      cpu: 500m
-      memory: 1Gi
+      cpu: 10m
+      memory: 192Mi
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -75,15 +75,15 @@ graphql:
 
   labels: {}
   annotations: {}
-  replicas: 2
+  replicas: 1
   strategy: {}
   podSecurityContext: {}
   securityContext: {}
   env: {}
   resources:
     requests:
-      cpu: 100m
-      memory: 256Mi
+      cpu: 10m
+      memory: 64Mi
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -115,15 +115,15 @@ apollo:
 
   labels: {}
   annotations: {}
-  replicas: 2
+  replicas: 1
   strategy: {}
   podSecurityContext: {}
   securityContext: {}
   env: {}
   resources:
     requests:
-      cpu: 300m
-      memory: 256Mi
+      cpu: 10m
+      memory: 64Mi
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -155,7 +155,10 @@ ui:
   podSecurityContext: {}
   securityContext: {}
   env: {}
-  resources: {}
+  resources:
+    requests:
+      cpu: 10m
+      memory: 16Mi
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -174,7 +177,10 @@ towel:
   podSecurityContext: {}
   securityContext: {}
   env: {}
-  resources: {}
+  resources:
+    requests:
+      cpu: 10m
+      memory: 80Mi
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -192,7 +198,7 @@ agent:
 
   labels: {}
   annotations: {}
-  replicas: 1
+  replicas: 0
   strategy: {}
   podSecurityContext: {}
   securityContext: {}

--- a/k8s/prefect_agents/basedosdados-perguntas/chart/values.yaml
+++ b/k8s/prefect_agents/basedosdados-perguntas/chart/values.yaml
@@ -7,7 +7,7 @@ agent:
   vertexServiceAccount: ''
   prefectLabels:
   - basedosdados-perguntas
-  replicas: 1
+  replicas: 0
   image:
     name: prefecthq/prefect
     tag: 0.15.9

--- a/k8s/prefect_agents/basedosdados-projetos/chart/values.yaml
+++ b/k8s/prefect_agents/basedosdados-projetos/chart/values.yaml
@@ -7,7 +7,7 @@ agent:
   vertexServiceAccount: ''
   prefectLabels:
   - basedosdados-projetos
-  replicas: 1
+  replicas: 0
   image:
     name: prefecthq/prefect
     tag: 0.15.9

--- a/k8s/prefect_agents/basedosdados/chart/values.yaml
+++ b/k8s/prefect_agents/basedosdados/chart/values.yaml
@@ -18,7 +18,7 @@ agent:
   name: prefect-agent
   prefectLabels:
   - basedosdados
-  replicas: 1
+  replicas: 0
   resources:
     limits:
       cpu: 100m


### PR DESCRIPTION
Closes #138

## Resumo

- Reduz requests de CPU/memória dos componentes do Prefect 0 (hasura, graphql, apollo, towel, ui) para valores compatíveis com o uso real
- Zera réplicas do `agent` no chart do servidor e nos 3 namespaces de agentes (`basedosdados`, `basedosdados-perguntas`, `basedosdados-projetos`)
- Evita reversão das mudanças já aplicadas via `kubectl` em caso de `helm upgrade`

## Mudanças

| Arquivo | Alteração |
|---|---|
| `k8s/prefect/chart/values.yaml` | Reduz requests de hasura/graphql/apollo; graphql e apollo: 2→1 réplica; agent: 1→0 réplica; towel e ui: adiciona requests mínimos |
| `k8s/prefect_agents/basedosdados/chart/values.yaml` | `replicas: 1 → 0` |
| `k8s/prefect_agents/basedosdados-perguntas/chart/values.yaml` | `replicas: 1 → 0` |
| `k8s/prefect_agents/basedosdados-projetos/chart/values.yaml` | `replicas: 1 → 0` |

## Recursos liberados

~1.35 cores CPU + ~1.7Gi memória de requests devolvidos ao scheduler do cluster.

## Test plan

- [ ] Verificar que `helm upgrade` com os novos values não reinicia pods com recursos maiores
- [ ] Confirmar que pods do Prefect 0 continuam rodando (apenas com resources menores, não deletados)
- [ ] Confirmar que agentes continuam em 0 réplicas após o upgrade