### PR TITLE
feat: reduce loki cache memory and add 6-month log retention

### DIFF
--- a/k8s/observability/loki/values.yaml
+++ b/k8s/observability/loki/values.yaml
@@ -16,6 +16,11 @@ loki:
   storage:
     type: filesystem
   auth_enabled: false
+  limits_config:
+    retention_period: 4320h  # 6 meses
+  compactor:
+    retention_enabled: true
+    delete_request_store: filesystem
 test:
   enabled: false
 lokiCanary:
@@ -30,3 +35,7 @@ read:
   replicas: 0
 write:
   replicas: 0
+chunksCache:
+  allocatedMemory: 512
+resultsCache:
+  allocatedMemory: 64


### PR DESCRIPTION
## Resumo

- `chunksCache.allocatedMemory`: 8192 MB → 512 MB (pico real 7d: 387Mi)
- `resultsCache.allocatedMemory`: 1024 MB → 64 MB (uso real constante: 2Mi)
- Retenção de 6 meses (4320h) via compactor — PVC cresce ~10 GB/mês, estado estável estimado em ~60 GB dos 100 GB disponíveis

## Motivação

Os valores de cache vinham dos defaults do chart e não estavam declarados no `values.yaml`, o que significa que qualquer `helm upgrade` futuro os redefiniria silenciosamente. Sem retenção configurada, o PVC de 100 Gi encheria em ~10 meses.

## Mudanças

- `k8s/observability/loki/values.yaml`: adicionados `chunksCache`, `resultsCache`, `limits_config.retention_period` e `compactor`