### PR TITLE
feat: dashboard de RAM por flow no Grafana

### DIFF
--- a/k8s/observability/prometheus/configmap.yaml
+++ b/k8s/observability/prometheus/configmap.yaml
@@ -573,40 +573,77 @@ data:
       "panels": [
         {
           "datasource": {
-            "type": "loki",
-            "uid": "lokiuid"
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": { "lineWidth": 2 },
+              "unit": "short"
+            }
           },
           "gridPos": {
             "h": 8,
-            "w": 11,
+            "w": 12,
             "x": 0,
             "y": 0
           },
           "id": 3,
           "options": {
-            "dedupStrategy": "none",
-            "enableLogDetails": true,
-            "prettifyLogMessage": false,
-            "showCommonLabels": false,
-            "showLabels": false,
-            "showTime": false,
-            "sortOrder": "Descending",
-            "wrapLogMessage": false
+            "legend": { "calcs": ["mean", "max"], "displayMode": "list", "placement": "bottom" },
+            "tooltip": { "mode": "single" }
           },
           "targets": [
             {
-              "datasource": {
-                "type": "loki",
-                "uid": "lokiuid"
-              },
-              "editorMode": "code",
-              "expr": "{app=\"prefect-server\"} | json | __error__=\"\" | line_format \"[{{ .timestamp | trunc 16 }}] {{ .detail_http_info_method }} {{ .detail_http_info_url }}\"",
-              "queryType": "range",
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "rate(container_cpu_usage_seconds_total{namespace=\"prefect3\", container=\"prefect-server\"}[5m])",
+              "legendFormat": "CPU (cores)",
               "refId": "A"
             }
           ],
-          "title": "Prefect Server",
-          "type": "logs"
+          "title": "Prefect Server — CPU",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": { "lineWidth": 2 },
+              "unit": "bytes"
+            }
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 0
+          },
+          "id": 6,
+          "options": {
+            "legend": { "calcs": ["mean", "max"], "displayMode": "list", "placement": "bottom" },
+            "tooltip": { "mode": "single" }
+          },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "container_memory_working_set_bytes{namespace=\"prefect3\", container=\"prefect-server\"}",
+              "legendFormat": "Memória usada",
+              "refId": "A"
+            },
+            {
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "kube_pod_container_resource_limits{namespace=\"prefect3\", container=\"prefect-server\", resource=\"memory\"}",
+              "legendFormat": "Limite",
+              "refId": "B"
+            }
+          ],
+          "title": "Prefect Server — Memória",
+          "type": "timeseries"
         },
         {
           "datasource": {
@@ -615,9 +652,9 @@ data:
           },
           "gridPos": {
             "h": 16,
-            "w": 11,
-            "x": 11,
-            "y": 0
+            "w": 12,
+            "x": 0,
+            "y": 8
           },
           "id": 1,
           "options": {
@@ -637,12 +674,12 @@ data:
                 "uid": "lokiuid"
               },
               "editorMode": "code",
-              "expr": "{app=\"prefect-job\"}",
+              "expr": "{namespace=\"prefect-worker-basedosdados\"}",
               "queryType": "range",
               "refId": "A"
             }
           ],
-          "title": "Prefect Job",
+          "title": "Flow Runs — Produção",
           "type": "logs"
         },
         {
@@ -651,9 +688,9 @@ data:
             "uid": "lokiuid"
           },
           "gridPos": {
-            "h": 8,
-            "w": 11,
-            "x": 0,
+            "h": 16,
+            "w": 12,
+            "x": 12,
             "y": 8
           },
           "id": 2,
@@ -674,87 +711,111 @@ data:
                 "uid": "lokiuid"
               },
               "editorMode": "code",
-              "expr": "{app=\"prefect-agent\"}",
+              "expr": "{namespace=\"prefect-worker-basedosdados-dev\"}",
               "queryType": "range",
               "refId": "A"
             }
           ],
-          "title": "Prefect Agent",
+          "title": "Flow Runs — Desenvolvimento",
           "type": "logs"
         },
         {
           "datasource": {
-            "type": "loki",
-            "uid": "lokiuid"
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "continuous-BlPu" },
+              "unit": "bytes",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 536870912 },
+                  { "color": "red", "value": 1073741824 }
+                ]
+              }
+            },
+            "overrides": []
           },
           "gridPos": {
-            "h": 8,
-            "w": 11,
+            "h": 12,
+            "w": 24,
             "x": 0,
-            "y": 16
+            "y": 24
           },
-          "id": 4,
+          "id": 7,
           "options": {
-            "dedupStrategy": "none",
-            "enableLogDetails": true,
-            "prettifyLogMessage": false,
-            "showCommonLabels": false,
-            "showLabels": false,
-            "showTime": false,
-            "sortOrder": "Descending",
-            "wrapLogMessage": false
+            "displayMode": "gradient",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": ["max"],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true
           },
           "targets": [
             {
-              "datasource": {
-                "type": "loki",
-                "uid": "lokiuid"
-              },
-              "editorMode": "code",
-              "expr": "{app=\"dbt-rpc-prod\"}",
-              "queryType": "range",
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "avg by (label_prefect_io_deployment_name) (\n  max_over_time(\n    prefect_job_memory_bytes{namespace=\"prefect-worker-basedosdados\"}\n  [30d])\n)",
+              "instant": true,
+              "legendFormat": "{{label_prefect_io_deployment_name}}",
               "refId": "A"
             }
           ],
-          "title": "dbt production",
-          "type": "logs"
+          "title": "RAM por flow — Produção (últimos 30 dias)",
+          "type": "bargauge"
         },
         {
           "datasource": {
-            "type": "loki",
-            "uid": "lokiuid"
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "continuous-GrYlRd" },
+              "unit": "bytes",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 536870912 },
+                  { "color": "red", "value": 1073741824 }
+                ]
+              }
+            },
+            "overrides": []
           },
           "gridPos": {
-            "h": 8,
-            "w": 11,
-            "x": 11,
-            "y": 16
+            "h": 12,
+            "w": 24,
+            "x": 0,
+            "y": 36
           },
-          "id": 5,
+          "id": 8,
           "options": {
-            "dedupStrategy": "none",
-            "enableLogDetails": true,
-            "prettifyLogMessage": false,
-            "showCommonLabels": false,
-            "showLabels": false,
-            "showTime": false,
-            "sortOrder": "Descending",
-            "wrapLogMessage": false
+            "displayMode": "gradient",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": ["max"],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true
           },
           "targets": [
             {
-              "datasource": {
-                "type": "loki",
-                "uid": "lokiuid"
-              },
-              "editorMode": "code",
-              "expr": "{app=\"dbt-rpc-dev\"}",
-              "queryType": "range",
+              "datasource": { "type": "prometheus", "uid": "prometheus" },
+              "expr": "avg by (label_prefect_io_deployment_name) (\n  max_over_time(\n    prefect_job_memory_bytes{namespace=\"prefect-worker-basedosdados-dev\"}\n  [30d])\n)",
+              "instant": true,
+              "legendFormat": "{{label_prefect_io_deployment_name}}",
               "refId": "A"
             }
           ],
-          "title": "dbt development",
-          "type": "logs"
+          "title": "RAM por flow — Desenvolvimento (últimos 30 dias)",
+          "type": "bargauge"
         }
       ],
       "schemaVersion": 39,
@@ -770,7 +831,7 @@ data:
       "timezone": "browser",
       "title": "Base dos Dados / Pipelines",
       "uid": "cdlzb0owwly4gd",
-      "version": 2,
+      "version": 5,
       "weekStart": ""
     }
 ---

--- a/k8s/observability/prometheus/configmap.yaml
+++ b/k8s/observability/prometheus/configmap.yaml
@@ -759,13 +759,13 @@ data:
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
-              "expr": "avg by (label_prefect_io_deployment_name) (\n  max_over_time(\n    prefect_job_memory_bytes{namespace=\"prefect-worker-basedosdados\"}\n  [30d])\n)",
+              "expr": "max by (label_prefect_io_deployment_name) (\n  max_over_time(\n    prefect_job_memory_bytes{namespace=\"prefect-worker-basedosdados\"}\n  [30d])\n)",
               "instant": true,
               "legendFormat": "{{label_prefect_io_deployment_name}}",
               "refId": "A"
             }
           ],
-          "title": "RAM por flow — Produção (últimos 30 dias)",
+          "title": "RAM por flow — Produção (pico máximo, últimos 30 dias)",
           "type": "bargauge"
         },
         {
@@ -808,13 +808,13 @@ data:
           "targets": [
             {
               "datasource": { "type": "prometheus", "uid": "prometheus" },
-              "expr": "avg by (label_prefect_io_deployment_name) (\n  max_over_time(\n    prefect_job_memory_bytes{namespace=\"prefect-worker-basedosdados-dev\"}\n  [30d])\n)",
+              "expr": "max by (label_prefect_io_deployment_name) (\n  max_over_time(\n    prefect_job_memory_bytes{namespace=\"prefect-worker-basedosdados-dev\"}\n  [30d])\n)",
               "instant": true,
               "legendFormat": "{{label_prefect_io_deployment_name}}",
               "refId": "A"
             }
           ],
-          "title": "RAM por flow — Desenvolvimento (últimos 30 dias)",
+          "title": "RAM por flow — Desenvolvimento (pico máximo, últimos 30 dias)",
           "type": "bargauge"
         }
       ],

--- a/k8s/observability/prometheus/prometheusrule-prefect-memory.yaml
+++ b/k8s/observability/prometheus/prometheusrule-prefect-memory.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: prefect-flow-memory
+  namespace: observability
+  labels:
+    release: prometheus
+spec:
+  groups:
+  - name: prefect.flow.memory
+    interval: 1m
+    rules:
+    - record: prefect_job_memory_bytes
+      expr: |
+        container_memory_working_set_bytes{namespace=~"prefect-worker-basedosdados.*", container="prefect-job"}
+        * on(pod, namespace) group_left(label_prefect_io_deployment_name)
+        kube_pod_labels{namespace=~"prefect-worker-basedosdados.*"}

--- a/k8s/observability/prometheus/values.yaml
+++ b/k8s/observability/prometheus/values.yaml
@@ -1036,7 +1036,7 @@ grafana:
       enabled: true
       org_name: Main Org.
       org_role: Editor
-    
+
     disable_login_form: true
 
   sidecar:
@@ -2003,6 +2003,8 @@ kube-state-metrics:
   rbac:
     create: true
   releaseLabel: true
+  extraArgs:
+    - --metric-labels-allowlist=pods=[prefect.io/deployment-name]
   prometheus:
     monitor:
       enabled: true

--- a/k8s/prefect/job_template/job_template.yaml
+++ b/k8s/prefect/job_template/job_template.yaml
@@ -2,6 +2,9 @@ apiVersion: batch/v1
 kind: Job
 spec:
   template:
+    metadata:
+      labels:
+        deployment: "{{ deployment.name }}"
     spec:
       containers:
       - name: flow


### PR DESCRIPTION
## Contexto

Fechando parte da issue de reativar observabilidade do Prefect 3. Adiciona painéis de consumo de RAM por deployment no dashboard \`Base dos Dados / Pipelines\` no Grafana.

## Problema

O cAdvisor expõe métricas de memória dos pods (\`container_memory_working_set_bytes\`) mas **não inclui labels de pod** — só container name, pod name e namespace. O nome do pod no Prefect é gerado aleatoriamente (\`exuberant-frog-nwjsz-r7tfg\`), então sem informação adicional é impossível saber qual deployment rodou.

## Solução

A solução tem três peças que precisaram ser configuradas fora do IAC também:

### 1. kube-state-metrics — expor labels de pod

O kube-state-metrics v2+ **não expõe labels de pod por padrão**. Sem isso, \`kube_pod_labels\` retorna vazio e qualquer join com cAdvisor falha silenciosamente.

**No IAC** (\`values.yaml\`): adiciona \`--metric-labels-allowlist=pods=[prefect.io/deployment-name]\` no kube-state-metrics.

**No cluster** (aplicado via \`kubectl patch\` para efeito imediato, sem aguardar Helm upgrade):
\`\`\`bash
kubectl patch deployment -n observability prometheus-kube-state-metrics \
  --type json \
  -p '[{"op": "add", "path": "/spec/template/spec/containers/0/args/-",
        "value": "--metric-labels-allowlist=pods=[prefect.io/deployment-name]"}]'
\`\`\`

### 2. Work pools — label de deployment no pod

O Prefect worker injeta \`prefect.io/deployment-name\` no pod automaticamente via \`_base_deployment_labels\` + \`_propagate_labels_to_pod\`, mas o pod template precisa ter \`metadata\` inicializado para o merge funcionar.

Tentativa inicial: adicionar \`deployment: "{{ deployment.name }}"\` no job template. Rejeitado pela API do Prefect com **422** — a API valida que toda variável \`{{ }}\` esteja declarada no schema do work pool, e \`deployment.name\` é uma variável de contexto do worker, não do schema.

Solução: usar \`"labels": "{{ labels }}"\` — \`labels\` **é** declarada no schema. O worker então resolve e propaga todos os labels incluindo \`prefect.io/deployment-name\`.

**No IAC** (\`job_template.yaml\`): atualizado com \`{{ labels }}\` no \`spec.template.metadata\`.

**Nos work pools** (aplicado via API do Prefect, pois o Prefect não lê o arquivo automaticamente):
\`\`\`bash
# Para basedosdados e basedosdados-dev
curl -X PATCH https://prefect3.basedosdados.org/api/work_pools/{pool} \
  -H "Authorization: Bearer $PREFECT_API_KEY" \
  -d '{"base_job_template": <template com labels no metadata>}'
\`\`\`

### 3. PrometheusRule — recording rule

Join entre \`container_memory_working_set_bytes\` e \`kube_pod_labels\` avaliado a cada 1 minuto, gravando \`prefect_job_memory_bytes\` com o label \`prefect.io/deployment-name\` no TSDB. O dado gravado **persiste após o pod ser deletado** — sem a recording rule, um join feito em tempo de query no Grafana não encontraria mais o pod e perderia o histórico.

### 4. Grafana — painéis

Dois painéis de bar gauge no dashboard Pipelines:
- **RAM por flow — Produção** (pico máximo, últimos 30 dias)
- **RAM por flow — Desenvolvimento** (pico máximo, últimos 30 dias)

Query:
\`\`\`promql
max by (label_prefect_io_deployment_name) (
  max_over_time(prefect_job_memory_bytes{namespace="prefect-worker-basedosdados"}[30d])
)
\`\`\`

Usa \`max\` (não \`avg\`) para ignorar execuções de flows que só verificam atualização e param sem processar dados — nesses casos o consumo de RAM é desprezível e não deve distorcer o resultado. O pico máximo histórico é o número relevante para right-sizing de pods.

## Arquivos neste PR

| Arquivo | Mudança |
|---|---|
| \`prometheusrule-prefect-memory.yaml\` | novo — recording rule \`prefect_job_memory_bytes\` |
| \`values.yaml\` | \`metric-labels-allowlist\` no kube-state-metrics |
| \`job_template.yaml\` | \`{{ labels }}\` no \`spec.template.metadata\` |
| \`configmap.yaml\` | dois painéis RAM + migração do Prefect Server de Loki → Prometheus |

## O que foi feito fora do IAC

| Ação | Onde |
|---|---|
| \`kubectl patch\` no kube-state-metrics | cluster (persistido via \`values.yaml\`) |
| PATCH nos work pools \`basedosdados\` e \`basedosdados-dev\` | API do Prefect 3 |

## Testes

- \`kube_pod_labels\` verificado no Prometheus com \`label_prefect_io_deployment_name\` populado
- Recording rule \`prefect_job_memory_bytes\` produzindo séries confirmado via API do Prometheus
- Flows disparados em dev e prod (\`etnia_indigena\`, \`br_rf_cnpj__empresas\`) — apareceram nos painéis após ~1 minuto com valores de RAM corretos